### PR TITLE
Fixed problem with 'allowBackward' to match expected behavior

### DIFF
--- a/RMStepsController/RMStepsBar.m
+++ b/RMStepsController/RMStepsBar.m
@@ -521,7 +521,7 @@
         
         if(CGRectContainsPoint(step.stepView.frame, touchLocation)) {
             NSInteger index = [self.stepDictionaries indexOfObject:aStepDict];
-            if(index < self.indexOfSelectedStep || self.allowBackward) {
+            if(index < self.indexOfSelectedStep && self.allowBackward) {
                 [self.delegate stepsBar:self shouldSelectStepAtIndex:index];
             }
         }


### PR DESCRIPTION
From a variable named `allowBackward` I would expect the following behavior:

If set to `YES` (or `true` in Swift) it would allow to go backward, so the index must be before the current index (so it actually is _backward_) **and** it must be _allowed_. This was working fine before my pull request and still is after it.

If set to `NO` (or `false` in Swift) it would disallow all previous steps from being chosen. This didn't work before because the _logical or_ meant it was enough to simply be a previous step. So effectively the option `allowBackward` didn't do anything before this fix.

For me this change makes this option work again, I hope this helps some people out there.
