### PR TITLE
fixed Xcode 8.3 warning

### DIFF
--- a/RMStepsController/RMStepsBar.m
+++ b/RMStepsController/RMStepsBar.m
@@ -52,7 +52,11 @@
 
 #pragma mark - Helper Classes
 
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
 @interface RMStepSeperatorView : UIView<CAAnimationDelegate>
+#else
+@interface RMStepSeperatorView : UIView
+#endif
 
 @property (nonatomic, strong) CAShapeLayer *leftShapeLayer;
 @property (nonatomic, strong) CAShapeLayer *rightShapeLayer;

--- a/RMStepsController/RMStepsBar.m
+++ b/RMStepsController/RMStepsBar.m
@@ -52,7 +52,7 @@
 
 #pragma mark - Helper Classes
 
-@interface RMStepSeperatorView : UIView
+@interface RMStepSeperatorView : UIView<CAAnimationDelegate>
 
 @property (nonatomic, strong) CAShapeLayer *leftShapeLayer;
 @property (nonatomic, strong) CAShapeLayer *rightShapeLayer;

--- a/RMStepsController/RMStepsController.m
+++ b/RMStepsController/RMStepsController.m
@@ -194,13 +194,9 @@
     [self updateContentInsetsForViewController:self.currentStepViewController];
 }
 
--(NSInteger) currentStepIndex {
-    return [self.childViewControllers indexOfObject:self.currentStepViewController];
-}
-
 #pragma mark - Actions
 - (void)showNextStep {
-    NSInteger index = [self currentStepIndex];
+    NSInteger index = [self.childViewControllers indexOfObject:self.currentStepViewController];
     if(index < [self.childViewControllers count]-1) {
         UIViewController *nextStepViewController = [self.childViewControllers objectAtIndex:index+1];
         [self showStepViewController:nextStepViewController animated:YES];
@@ -210,7 +206,7 @@
 }
 
 - (void)showPreviousStep {
-    NSInteger index = [self currentStepIndex];
+    NSInteger index = [self.childViewControllers indexOfObject:self.currentStepViewController];
     if(index > 0) {
         UIViewController *nextStepViewController = [self.childViewControllers objectAtIndex:index-1];
         [self showStepViewController:nextStepViewController animated:YES];

--- a/RMStepsController/RMStepsController.m
+++ b/RMStepsController/RMStepsController.m
@@ -194,9 +194,13 @@
     [self updateContentInsetsForViewController:self.currentStepViewController];
 }
 
+-(NSInteger) currentStepIndex {
+    return [self.childViewControllers indexOfObject:self.currentStepViewController];
+}
+
 #pragma mark - Actions
 - (void)showNextStep {
-    NSInteger index = [self.childViewControllers indexOfObject:self.currentStepViewController];
+    NSInteger index = [self currentStepIndex];
     if(index < [self.childViewControllers count]-1) {
         UIViewController *nextStepViewController = [self.childViewControllers objectAtIndex:index+1];
         [self showStepViewController:nextStepViewController animated:YES];
@@ -206,7 +210,7 @@
 }
 
 - (void)showPreviousStep {
-    NSInteger index = [self.childViewControllers indexOfObject:self.currentStepViewController];
+    NSInteger index = [self currentStepIndex];
     if(index > 0) {
         UIViewController *nextStepViewController = [self.childViewControllers objectAtIndex:index-1];
         [self showStepViewController:nextStepViewController animated:YES];


### PR DESCRIPTION
Xcode warning fixed:

```
./RMStepsController/RMStepsController/RMStepsBar.m:116:37: warning:
assigning to 'id<CAAnimationDelegate> _Nullable' from incompatible type
'RMStepSeperatorView *const __strong'
        fillColorAnimation.delegate = self;
                                    ^ ~~~~
./RMStepsController/RMStepsController/RMStepsBar.m:133:37: warning:
assigning to 'id<CAAnimationDelegate> _Nullable' from incompatible type
'RMStepSeperatorView *const __strong'
        fillColorAnimation.delegate = self;
                                    ^ ~~~~
```